### PR TITLE
Fix incorrect placement of port= when getting port from environ.

### DIFF
--- a/tor_.py
+++ b/tor_.py
@@ -52,7 +52,7 @@ def gen_controller():
     connect_method = os.environ.get('connectmethod', 'port')
 
     if connect_method == 'port':
-        return Controller.from_port(int(port=os.environ.get('port', 9051)))
+        return Controller.from_port(port=int(os.environ.get('port', 9051)))
     elif connect_method == 'socket':
         return Controller.from_socket_file(path=os.environ.get('socket', '/var/run/tor/control'))
     else:


### PR DESCRIPTION
Looks like b6597671bd283673a58aea25bdc5360498a1a68a misplaced the `int(` slightly, causing problems.